### PR TITLE
Reword confidence messages and add ruleId

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,9 +27,7 @@ var spacheFormula = require('spache-formula');
 /* Constants. */
 var DEFAULT_TARGET_AGE = 16;
 var WORDYNESS_THRESHOLD = 5;
-var CONFIDENCE_THRESHOLD_LOW = 4 / 7;
-var CONFIDENCE_THRESHOLD_MODERATE = 5 / 7;
-var CONFIDENCE_THRESHOLD_HIGH = 6 / 7;
+var CONFIDENCE_THRESHOLD = 4 / 7;
 
 /* Methods. */
 var has = {}.hasOwnProperty;
@@ -87,36 +85,20 @@ function smogToAge(value) {
  *   for `node` according to several algorithms.
  */
 function report(file, node, threshold, target, results) {
-    var length = results.length;
-    var confidence = 0;
-    var index = -1;
-    var confidenceLevel;
     var message;
+    var failCount = results.filter(function (res) {
+        return res > target;
+    }).length;
+    var confidence = failCount + '/' + results.length;
 
-    while (++index < length) {
-        if (results[index] > target) {
-            confidence++;
-        }
-    }
-
-    confidence /= length;
-
-    if (confidence >= threshold) {
-        if (confidence >= CONFIDENCE_THRESHOLD_HIGH) {
-            confidenceLevel = 'high';
-        } else if (confidence >= CONFIDENCE_THRESHOLD_MODERATE) {
-            confidenceLevel = 'moderate';
-        } else {
-            confidenceLevel = 'low';
-        }
+    if (failCount / results.length >= threshold) {
 
         message = file.warn(
-            'Hard to read sentence (confidence: ' + confidenceLevel + ')',
+            'Hard to read sentence (confidence: ' + confidence + ')',
             node,
             'retext-readability'
         );
 
-        message.confidenceLevel = confidenceLevel;
         message.confidence = confidence;
         message.source = 'retext-readability';
     }
@@ -132,7 +114,7 @@ function report(file, node, threshold, target, results) {
 function attacher(processor, options) {
     var settings = options || {};
     var targetAge = settings.age || DEFAULT_TARGET_AGE;
-    var threshold = settings.threshold || CONFIDENCE_THRESHOLD_LOW;
+    var threshold = settings.threshold || CONFIDENCE_THRESHOLD;
     var minWords = settings.minWords;
 
     if (minWords === null || minWords === undefined) {

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Yields:
 
 ```txt
 <stdin>
-   3:1-5:57  warning  Hard to read sentence (confidence: moderate)     hard-to-read
+   3:1-5:57  warning  Hard to read sentence (confidence: 5/7)          hard-to-read
 
 ⚠ 1 warning
 ```
@@ -66,8 +66,8 @@ Yields:
 
 ```txt
 <stdin>
-   1:1-1:23  warning  Hard to read sentence (confidence: low)          hard-to-read
-   3:1-5:57  warning  Hard to read sentence (confidence: high)         hard-to-read
+   1:1-1:23  warning  Hard to read sentence (confidence: 4/7)          hard-to-read
+   3:1-5:57  warning  Hard to read sentence (confidence: 6/7)          hard-to-read
 
 ⚠ 2 warnings
 ```

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Yields:
 
 ```txt
 <stdin>
-   3:1-5:57  warning  Very hard to read sentence
+   3:1-5:57  warning  Hard to read sentence (confidence: moderate)     hard-to-read
 
 ⚠ 1 warning
 ```
@@ -66,8 +66,8 @@ Yields:
 
 ```txt
 <stdin>
-   1:1-1:23  warning  Quite hard to read sentence
-   3:1-5:57  warning  Definitely hard to read sentence
+   1:1-1:23  warning  Hard to read sentence (confidence: low)          hard-to-read
+   3:1-5:57  warning  Hard to read sentence (confidence: high)         hard-to-read
 
 ⚠ 2 warnings
 ```

--- a/test.js
+++ b/test.js
@@ -43,7 +43,7 @@ test('readability', function (t) {
 
             t.deepEqual(
                 file.messages.map(String),
-                ['1:1-3:32: Hard to read sentence (confidence: low)'],
+                ['1:1-3:32: Hard to read sentence (confidence: 4/7)'],
                 'should warn when low confidence that a sentence is hard to read'
             );
         });
@@ -100,7 +100,7 @@ test('readability', function (t) {
 
             t.deepEqual(
                 file.messages.map(String),
-                ['1:1-3:32: Hard to read sentence (confidence: moderate)'],
+                ['1:1-3:32: Hard to read sentence (confidence: 5/7)'],
                 'should support a given age (upping the warning)'
             );
         });
@@ -117,7 +117,7 @@ test('readability', function (t) {
 
             t.deepEqual(
                 file.messages.map(String),
-                ['1:1-3:46: Hard to read sentence (confidence: moderate)'],
+                ['1:1-3:46: Hard to read sentence (confidence: 5/7)'],
                 'should warn when moderately confident that a sentence is hard to read'
             );
         });
@@ -137,7 +137,7 @@ test('readability', function (t) {
 
             t.deepEqual(
                 file.messages.map(String),
-                ['1:1-4:45: Hard to read sentence (confidence: high)'],
+                ['1:1-4:45: Hard to read sentence (confidence: 6/7)'],
                 'should warn when highly confident that a sentence is hard to read'
             );
         });
@@ -163,7 +163,7 @@ test('readability', function (t) {
 
             t.deepEqual(
                 file.messages.map(String),
-                ['1:1-1:29: Hard to read sentence (confidence: low)'],
+                ['1:1-1:29: Hard to read sentence (confidence: 4/7)'],
                 'should support `minWords` (config)'
             );
         });

--- a/test.js
+++ b/test.js
@@ -43,8 +43,8 @@ test('readability', function (t) {
 
             t.deepEqual(
                 file.messages.map(String),
-                ['1:1-3:32: Quite hard to read sentence'],
-                'should warn when a sentence is quite hard to read'
+                ['1:1-3:32: Hard to read sentence (confidence: low)'],
+                'should warn when low confidence that a sentence is hard to read'
             );
         });
 
@@ -100,7 +100,7 @@ test('readability', function (t) {
 
             t.deepEqual(
                 file.messages.map(String),
-                ['1:1-3:32: Very hard to read sentence'],
+                ['1:1-3:32: Hard to read sentence (confidence: moderate)'],
                 'should support a given age (upping the warning)'
             );
         });
@@ -117,8 +117,8 @@ test('readability', function (t) {
 
             t.deepEqual(
                 file.messages.map(String),
-                ['1:1-3:46: Very hard to read sentence'],
-                'should warn when a sentence is very hard to read'
+                ['1:1-3:46: Hard to read sentence (confidence: moderate)'],
+                'should warn when moderately confident that a sentence is hard to read'
             );
         });
 
@@ -137,8 +137,8 @@ test('readability', function (t) {
 
             t.deepEqual(
                 file.messages.map(String),
-                ['1:1-4:45: Definitely hard to read sentence'],
-                'should warn when a sentence is definitely hard to read'
+                ['1:1-4:45: Hard to read sentence (confidence: high)'],
+                'should warn when highly confident that a sentence is hard to read'
             );
         });
 
@@ -163,7 +163,7 @@ test('readability', function (t) {
 
             t.deepEqual(
                 file.messages.map(String),
-                ['1:1-1:29: Quite hard to read sentence'],
+                ['1:1-1:29: Hard to read sentence (confidence: low)'],
                 'should support `minWords` (config)'
             );
         });


### PR DESCRIPTION
Resolves #4. Rewords confidence messages and adds `ruleId`. I decided to use the word "confidence" instead of "sureness" both in the messages and internally for clarity and consistency. Messages now look like this;
```
5:1-5:68  warning    Hard to read sentence, low confidence           hard-to-read
6:1-6:86  warning    Hard to read sentence, moderate confidence      hard-to-read
7:1-7:98  warning    Hard to read sentence, high confidence          hard-to-read
```